### PR TITLE
feat: 온보딩 - 직무 선택 저장 API 구현

### DIFF
--- a/src/main/java/com/example/career/domain/member/entity/Member.java
+++ b/src/main/java/com/example/career/domain/member/entity/Member.java
@@ -1,14 +1,18 @@
 package com.example.career.domain.member.entity;
 
 import com.example.career.domain.member.enums.Gender;
+import com.example.career.domain.onboarding.entity.Job;
 import com.example.career.global.common.SoftDeletableEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -42,6 +46,10 @@ public class Member extends SoftDeletableEntity {
     @Column(nullable = false)
     private Gender gender;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "job_id")
+    private Job job;
+
     public Member(String email, String password, String name, String birth, String phone, Gender gender) {
         this.email = email;
         this.password = password;
@@ -54,4 +62,9 @@ public class Member extends SoftDeletableEntity {
     public void updatePassword(String newEncodedPassword) {
         this.password = newEncodedPassword;
     }
+
+    public void selectJob(Job job) {
+        this.job = job;
+    }
+
 }

--- a/src/main/java/com/example/career/domain/onboarding/controller/OnboardingController.java
+++ b/src/main/java/com/example/career/domain/onboarding/controller/OnboardingController.java
@@ -1,0 +1,36 @@
+package com.example.career.domain.onboarding.controller;
+
+import com.example.career.domain.onboarding.dto.JobSelectionRequestDto;
+import com.example.career.domain.onboarding.dto.JobSelectionResponseDto;
+import com.example.career.domain.onboarding.service.OnboardingService;
+import com.example.career.global.common.CommonResponseDto;
+import com.example.career.global.common.SuccessCode;
+import com.example.career.global.security.MemberDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/onboarding")
+@RequiredArgsConstructor
+@Tag(name = "Onboarding", description = "온보딩 관련 API")
+public class OnboardingController {
+
+    private final OnboardingService onboardingService;
+
+    @PostMapping("/jobs")
+    @Operation(summary = "직무 선택 저장", description = "사용자가 선택한 직무를 저장")
+    public ResponseEntity<CommonResponseDto<JobSelectionResponseDto>> saveJobSelection(@AuthenticationPrincipal MemberDetails user,
+                                                                                       @RequestBody @Valid JobSelectionRequestDto jobSelectionRequestDto) {
+        JobSelectionResponseDto jobSelectionResponseDto = onboardingService.saveJobSelection(user, jobSelectionRequestDto);
+
+        return ResponseEntity.ok(CommonResponseDto.success(SuccessCode.CREATE_SUCCESS, jobSelectionResponseDto));
+    }
+}

--- a/src/main/java/com/example/career/domain/onboarding/dto/JobSelectionRequestDto.java
+++ b/src/main/java/com/example/career/domain/onboarding/dto/JobSelectionRequestDto.java
@@ -1,0 +1,17 @@
+package com.example.career.domain.onboarding.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class JobSelectionRequestDto {
+
+    @NotBlank(message = "직업 코드는 필수입니다.")
+    private String jobCode;
+
+    public JobSelectionRequestDto(String jobCode) {
+        this.jobCode = jobCode;
+    }
+}

--- a/src/main/java/com/example/career/domain/onboarding/dto/JobSelectionResponseDto.java
+++ b/src/main/java/com/example/career/domain/onboarding/dto/JobSelectionResponseDto.java
@@ -1,0 +1,12 @@
+package com.example.career.domain.onboarding.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class JobSelectionResponseDto {
+
+    private final String jobCode;
+    private final String jobName;
+}

--- a/src/main/java/com/example/career/domain/onboarding/repository/JobRepository.java
+++ b/src/main/java/com/example/career/domain/onboarding/repository/JobRepository.java
@@ -4,6 +4,7 @@ import com.example.career.domain.onboarding.entity.Job;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface JobRepository extends JpaRepository<Job, Long> {
 
@@ -11,4 +12,5 @@ public interface JobRepository extends JpaRepository<Job, Long> {
 
     boolean existsByCode(String code);
 
+    Optional<Job> findByCode(String code);
 }

--- a/src/main/java/com/example/career/domain/onboarding/service/OnboardingService.java
+++ b/src/main/java/com/example/career/domain/onboarding/service/OnboardingService.java
@@ -1,0 +1,37 @@
+package com.example.career.domain.onboarding.service;
+
+import com.example.career.domain.member.entity.Member;
+import com.example.career.domain.member.repository.MemberRepository;
+import com.example.career.domain.onboarding.dto.JobSelectionRequestDto;
+import com.example.career.domain.onboarding.dto.JobSelectionResponseDto;
+import com.example.career.domain.onboarding.entity.Job;
+import com.example.career.domain.onboarding.repository.JobRepository;
+import com.example.career.global.error.errorcode.ErrorCode;
+import com.example.career.global.error.exception.BadRequestException;
+import com.example.career.global.security.MemberDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OnboardingService {
+
+    private final MemberRepository memberRepository;
+    private final JobRepository jobRepository;
+
+    @Transactional
+    public JobSelectionResponseDto saveJobSelection(MemberDetails user, JobSelectionRequestDto jobSelectionRequestDto) {
+        Long memberId = user.getMember().getId();
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BadRequestException(ErrorCode.MEMBER_NOT_FOUND));
+
+        Job job = jobRepository.findByCode(jobSelectionRequestDto.getJobCode())
+                .orElseThrow(() -> new BadRequestException(ErrorCode.JOB_NOT_FOUND));
+
+        member.selectJob(job);
+
+        return new JobSelectionResponseDto(job.getCode(), job.getName());
+    }
+}

--- a/src/main/java/com/example/career/global/error/errorcode/ErrorCode.java
+++ b/src/main/java/com/example/career/global/error/errorcode/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
 
     // NOT_FOUND
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회원을 찾을 수 없습니다."),
+    JOB_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 직업을 찾을 수 없습니다."),
 
     // CONFLICT
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),


### PR DESCRIPTION
-JobSelectionRequestDto: jobCode 필드로 요청 값 받기
-JobSelectionResponseDto: 선택된 직무 정보 응답 반환
-JobRepository.findByCode() 추가로 직무 조회
-ErrorCode.JOB_NOT_FOUND 정의
-Member.selectJob(job): setter 지양하고 의미 있는 메서드 도입
-OnboardingService 사용자 → 직무 연결 저장 로직 구현