### PR TITLE
feat: 카카오 소셜 로그인 기능 구현(프론트 연결 후 테스트 예정)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-configuration-processor'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     implementation 'io.github.cdimascio:java-dotenv:5.2.2'
@@ -56,7 +57,10 @@ dependencies {
 
     // spring security
     implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    // JSON parsing
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
 
     // BCrypt
     implementation 'org.springframework.security:spring-security-crypto'
@@ -64,6 +68,7 @@ dependencies {
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.jetbrains:annotations:24.0.1'
+    implementation 'org.springframework:spring-web'
 
     // webflux
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
@@ -78,6 +83,9 @@ dependencies {
     // Email Verify
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'com.sun.mail:jakarta.mail:2.0.1'
+
+    // OAuth Request
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/example/career/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/example/career/domain/member/entity/Member.java
@@ -1,10 +1,13 @@
 package com.example.career.domain.member.entity;
 
+import com.example.career.domain.oauth.enums.AuthProvider;
 import com.example.career.domain.onboarding.entity.Job;
 import com.example.career.domain.onboarding.entity.Onboarding;
 import com.example.career.global.common.SoftDeletableEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -29,8 +32,12 @@ public class Member extends SoftDeletableEntity {
     @Column(length = 320, nullable = false, unique = true)
     private String email;
 
-    @Column(length = 255, nullable = false)
+    @Column(length = 255, nullable = true)
     private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AuthProvider authProvider;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "job_id")
@@ -42,6 +49,14 @@ public class Member extends SoftDeletableEntity {
     public Member(String email, String password) {
         this.email = email;
         this.password = password;
+    }
+
+    public static Member kakaoUser(String email) {
+        Member member = new Member();
+        member.email = email;
+        member.authProvider = AuthProvider.KAKAO;
+        member.password = null;
+        return member;
     }
 
     public void updatePassword(String newEncodedPassword) {

--- a/backend/src/main/java/com/example/career/domain/oauth/controller/OAuthController.java
+++ b/backend/src/main/java/com/example/career/domain/oauth/controller/OAuthController.java
@@ -1,0 +1,29 @@
+package com.example.career.domain.oauth.controller;
+
+import com.example.career.domain.member.dto.LoginResponseDto;
+import com.example.career.domain.oauth.service.KakaoOAuthService;
+import com.example.career.global.common.CommonResponseDto;
+import com.example.career.global.common.SuccessCode;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+@Tag(name = "Auth", description = "소셜 로그인 API")
+public class OAuthController {
+
+    private final KakaoOAuthService kakaoOAuthService;
+
+    @GetMapping("kakao/callback")
+    public ResponseEntity<CommonResponseDto<LoginResponseDto>> kakaoLogin(@RequestParam String code) {
+        LoginResponseDto loginResponseDto = kakaoOAuthService.kakaoLogin(code);
+
+        return ResponseEntity.ok(CommonResponseDto.success(SuccessCode.LOGIN_SUCCESS, loginResponseDto));
+    }
+}

--- a/backend/src/main/java/com/example/career/domain/oauth/dto/KakaoTokenResponse.java
+++ b/backend/src/main/java/com/example/career/domain/oauth/dto/KakaoTokenResponse.java
@@ -1,0 +1,15 @@
+package com.example.career.domain.oauth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class KakaoTokenResponse {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+}

--- a/backend/src/main/java/com/example/career/domain/oauth/dto/KakaoUserInfo.java
+++ b/backend/src/main/java/com/example/career/domain/oauth/dto/KakaoUserInfo.java
@@ -1,0 +1,16 @@
+package com.example.career.domain.oauth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class KakaoUserInfo {
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    @Getter
+    public static class KakaoAccount {
+        private String email;
+    }
+}

--- a/backend/src/main/java/com/example/career/domain/oauth/enums/AuthProvider.java
+++ b/backend/src/main/java/com/example/career/domain/oauth/enums/AuthProvider.java
@@ -1,0 +1,6 @@
+package com.example.career.domain.oauth.enums;
+
+public enum AuthProvider {
+    LOCAL,
+    KAKAO
+}

--- a/backend/src/main/java/com/example/career/domain/oauth/service/KakaoOAuthService.java
+++ b/backend/src/main/java/com/example/career/domain/oauth/service/KakaoOAuthService.java
@@ -1,0 +1,82 @@
+package com.example.career.domain.oauth.service;
+
+import com.example.career.domain.member.dto.LoginResponseDto;
+import com.example.career.domain.member.entity.Member;
+import com.example.career.domain.member.repository.MemberRepository;
+import com.example.career.domain.oauth.dto.KakaoTokenResponse;
+import com.example.career.domain.oauth.dto.KakaoUserInfo;
+import com.example.career.global.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoOAuthService {
+
+    @Qualifier("kakaoTokenClient")
+    private final WebClient kakaoTokenClient;
+
+    @Qualifier("kakaoUserInfoClient")
+    private final WebClient kakaoUserInfoClient;
+
+    private final MemberRepository memberRepository;
+    private final JwtProvider jwtProvider;
+
+    @Value("${kakao.client-id}")
+    private String clientId;
+
+    @Value("${kakao.redirect-uri}")
+    private String redirectUri;
+
+    @Value("${kakao.token-uri}")
+    private String tokenUri;
+
+    @Value("${kakao.user-info-uri}")
+    private String userInfoUri;
+
+    public LoginResponseDto kakaoLogin(String code) {
+        KakaoTokenResponse tokenResponse = getAccessToken(code);
+        KakaoUserInfo userInfo = getUserInfo(tokenResponse.getAccessToken());
+        String email = userInfo.getKakaoAccount().getEmail();
+
+        Member member = memberRepository.findByEmail(email)
+                .orElseGet(() -> memberRepository.save(Member.kakaoUser(email)));
+
+        String accessToken = jwtProvider.generateAccessToken(email);
+        String refreshToken = jwtProvider.generateRefreshToken(email);
+
+        return new LoginResponseDto(accessToken, refreshToken);
+    }
+
+    private KakaoTokenResponse getAccessToken(String code) {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", clientId);
+        params.add("redirect_uri", redirectUri);
+        params.add("code", code);
+
+        return kakaoTokenClient.post()
+                .uri("/oauth/token")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(BodyInserters.fromFormData(params))
+                .retrieve()
+                .bodyToMono(KakaoTokenResponse.class)
+                .block();
+    }
+
+    private KakaoUserInfo getUserInfo(String accessToken) {
+        return kakaoUserInfoClient.get()
+                .uri("/v2/user/me")
+                .headers(headers -> headers.setBearerAuth(accessToken))
+                .retrieve()
+                .bodyToMono(KakaoUserInfo.class)
+                .block();
+    }
+}

--- a/backend/src/main/java/com/example/career/global/config/KakaoWebClientConfig.java
+++ b/backend/src/main/java/com/example/career/global/config/KakaoWebClientConfig.java
@@ -1,0 +1,28 @@
+package com.example.career.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class KakaoWebClientConfig {
+
+    @Bean("kakaoTokenClient")
+    public WebClient kakaoTokenClient() {
+        return WebClient.builder()
+                .baseUrl("https://kauth.kakao.com")
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .build();
+    }
+
+
+    @Bean("kakaoUserInfoClient")
+    public WebClient kakaoUserInfoClient() {
+        return WebClient.builder()
+                .baseUrl("https://kapi.kakao.com")
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -52,3 +52,8 @@ server.tomcat.accept-count=100
 management.endpoints.web.exposure.include=health
 management.endpoints.enabled-by-default=true
 management.endpoint.health.show-details=always
+## Kakao OAuth
+kakao.client-id=${KAKAO_CLIENT_ID}
+kakao.redirect-uri=${KAKAO_REDIRECT_URI}
+kakao.token-uri=https://kauth.kakao.com/oauth/token
+kakao.user-info-uri=https://kapi.kakao.com/v2/user/me


### PR DESCRIPTION
-WebClient 기반 Kakao access token 및 사용자 정보 요청 구현
-신규 사용자일 경우 이메일 기반 자동 회원가입 처리
-JWT access/refresh token 발급 및 로그인 응답 반환
-AuthProvider Enum 도입으로 소셜 로그인 구분 가능
-application.properties에 kakao 관련 설정 추가